### PR TITLE
Fix minimal aiida-core version to 1.3.0

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7.7, 3.8]
+        python-version: [3.6, 3.7.6, 3.8]
     services:
       postgres:
         image: postgres:10

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7.7, 3.8]
     services:
       postgres:
         image: postgres:10

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7.6, 3.8]
+        python-version: [3.6, 3.7.7, 3.8]
     services:
       postgres:
         image: postgres:10
@@ -78,4 +78,4 @@ jobs:
 
     - name: Test package using pytest
       run: |
-        pytest
+        pytest tests

--- a/aiida_cusp/calculators/calculation_base.py
+++ b/aiida_cusp/calculators/calculation_base.py
@@ -171,8 +171,6 @@ class CalculationBase(CalcJob):
         scheduler = computer.get_scheduler()
         resources = self.inputs.metadata.options.resources
         default_cpus_machine = computer.get_default_mpiprocs_per_machine()
-        if default_cpus_machine is not None:
-            resources['default_mpiprocs_per_machine'] = default_cpus_machine
         job_resource = scheduler.create_job_resource(**resources)
         tot_num_mpiprocs = job_resource.get_tot_num_mpiprocs()
         mpi_arg_dict = {'tot_num_mpiprocs': tot_num_mpiprocs}

--- a/setup.json
+++ b/setup.json
@@ -36,7 +36,7 @@
 			]
     },
     "install_requires": [
-      "aiida-core>=1.2.1,<2.0.0",
+      "aiida-core>=1.3.0,<2.0.0",
       "custodian",
       "pymatgen",
 			"ase"


### PR DESCRIPTION
Minimal aiida-core version has to be fixed due to the recently
introduced change in the aiida-core package moving the resources
validation to the scheduler plugin.

see https://github.com/aiidateam/aiida-core/pull/4192