### PR TITLE
Add long_description_content_type in setup.json

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -15,6 +15,7 @@
 			"Framework :: AiiDA"
 		],
 		"description": "Custodian based VASP Plugin for AiiDA",
+		"long_description_content_type": "text/markdown",
     "url": "https://github.com/astamminger/aiida-cusp",
     "license": "MIT License",
 		"reentry_register": true,


### PR DESCRIPTION
fixes #12 

This commits extends the setup.json with the `long_description_content_type` key and sets it to `text/markdown` to force PyPI to render the package's long description that is taken from the README.md as markdown