### PR TITLE
Replace deprecated methods and keywords

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,9 +182,9 @@ def computer(tmpdir):
     Setup a new computer object.
     """
     from aiida.orm import Computer, User
-    computer = Computer(name='local_computer', hostname='localhost')
-    computer.set_scheduler_type('direct')
-    computer.set_transport_type('local')
+    computer = Computer(label='local_computer', hostname='localhost')
+    computer.scheduler_type = 'direct'
+    computer.transport_type = 'local'
     computer.set_workdir(str(tmpdir))
     computer.set_default_mpiprocs_per_machine(1)
     computer.set_mpirun_command(['mpirun', '-np', '{tot_num_mpiprocs}'])


### PR DESCRIPTION
Several  methods in the latest AiiDA releases have been deprecated. In this pull request the deprecated methods are replaced with their new counterparts, i.e. 

* `set_transport_type()` method --> replaced by `transport_type` property
* `set_scheduler_type()` method --> replaced by `scheduler_type` property
* computer attribute `name` --> replaced by attribute `label`