### PR TITLE
add new handlers

### DIFF
--- a/aiida_cusp/utils/defaults.py
+++ b/aiida_cusp/utils/defaults.py
@@ -203,7 +203,9 @@ class CustodianDefaults(object):
                 'output_filename': PluginDefaults.STDOUT_FNAME,
                 'timeout': 21600,
             },
-            'IncorrectSmearingHandler': {},
+            'IncorrectSmearingHandler': {
+                'output_filename': VaspDefaults.FNAMES['vasprun'],
+            },
             'LargeSigmaHandler': {},
             'LrfCommutatorHandler': {
                 'output_filename': PluginDefaults.STDERR_FNAME,

--- a/aiida_cusp/utils/defaults.py
+++ b/aiida_cusp/utils/defaults.py
@@ -203,7 +203,7 @@ class CustodianDefaults(object):
                 'output_filename': PluginDefaults.STDOUT_FNAME,
                 'timeout': 21600,
             },
-            'IncorrectSmearingHandler':{},  
+            'IncorrectSmearingHandler': {},
             'LargeSigmaHandler': {},
             'LrfCommutatorHandler': {
                 'output_filename': PluginDefaults.STDERR_FNAME,

--- a/aiida_cusp/utils/defaults.py
+++ b/aiida_cusp/utils/defaults.py
@@ -203,6 +203,8 @@ class CustodianDefaults(object):
                 'output_filename': PluginDefaults.STDOUT_FNAME,
                 'timeout': 21600,
             },
+            'IncorrectSmearingHandler':{}, 
+            'LargeSigmaHandler': {},
             'LrfCommutatorHandler': {
                 'output_filename': PluginDefaults.STDERR_FNAME,
             },

--- a/aiida_cusp/utils/defaults.py
+++ b/aiida_cusp/utils/defaults.py
@@ -203,6 +203,8 @@ class CustodianDefaults(object):
                 'output_filename': PluginDefaults.STDOUT_FNAME,
                 'timeout': 21600,
             },
+            'IncorrectSmearingHandler':{},  
+            'LargeSigmaHandler': {},
             'LrfCommutatorHandler': {
                 'output_filename': PluginDefaults.STDERR_FNAME,
             },

--- a/setup.json
+++ b/setup.json
@@ -45,7 +45,7 @@
     },
     "install_requires": [
       "aiida-core>=1.3.0,<2.0.0",
-      "custodian",
+      "custodian>=2021.1.7",
       "pymatgen>=2022.0.0",
 			"ase"
     ],


### PR DESCRIPTION
The old default list seems to miss two error handlers from Custodian 2022.5.26