### PR TITLE
enable custodian double relaxation

### DIFF
--- a/aiida_cusp/calculators/calculation_base.py
+++ b/aiida_cusp/calculators/calculation_base.py
@@ -295,6 +295,8 @@ class CalculationBase(CalcJob):
 
         for name, abspath, relpath in self.remote_filelist(remote_data):
 
+            bare_name = name
+
             # detect suffix and take it out
             has_suffix = False
             current_suffix = ""

--- a/tests/parsers/vasp_file_parser_test.py
+++ b/tests/parsers/vasp_file_parser_test.py
@@ -21,7 +21,7 @@ def test_normalize_filename(vasp_file_parser, filename, subfolder,
     import pathlib
     # construct some arbitrary absolute path to the file
     filepath = pathlib.Path().absolute() / subfolder / filename
-    normalized = vasp_file_parser.normalized_filename(filepath)
+    normalized = vasp_file_parser.normalized_filename(filepath.name)
     assert normalized == expected_normalized
 
 


### PR DESCRIPTION
This pull is to use the aiida-cusp calculations to enable the standard custodian workflow. To enable the change, a couple places are modified

- enable user defined custodian job lists, so the `cstdn_spec.yml` can contain more than one jobs
- allow the output nodes to contain multiple `outcar`, `vasprun.xml` by checking suffix in the parsers

The way to use the new function is like below

```python
    vasp_job = CalculationFactory("cusp.vasp").get_builder()
    ....
    vasp_job.incar = VaspIncarData(incar=mp_set.incar)
    ...

    jobs = custodian.VaspJob.double_relaxation_run(
            vasp_cmd="null",
            auto_npar=auto_npar,
            ediffg=ediffg,
            half_kpts_first_relax=half_kpts_first_relax,
     )
    vasp_job.custodian.settings = dict(max_errors=max_errors)
    vasp_job.custodian.jobs = {
        f"{idx}": {
            k: v
            for k, v in job.__dict__.items()
            if k not in ["vasp_cmd", "vasp.out", "stderr_file"]
        }
        for idx, job in enumerate(jobs)
    }
    ...
    submit(vasp_job)
```