### PR TITLE
Switch to Flake8 GitHub repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: check-yaml
   - id: fix-encoding-pragma
   - id: trailing-whitespace
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.8.1
   hooks:
   - id: flake8


### PR DESCRIPTION
Update the used Flake8 repository inside the .pre-commit-config.yaml As they decided to move from GitLab to GitHub the previous GitLab repository URL does not work anymore and fails the pre-commit hook