### PR TITLE
Add OS option to .readthedocs.yaml build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,18 +4,19 @@ formats: []
 
 # build process definition
 build:
+  os: ubuntu-22.04
   tools:
     python: "3.8"
 
 # used python environment configuration
 python:
-    install:
-        - method: pip
-          path: .
-          extra_requirements:
-            - docs
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 # fail sphinx build on warnings
 sphinx:
-    builder: html
-    fail_on_warning: true
+  builder: html
+  fail_on_warning: true


### PR DESCRIPTION
This commit adds the `os:` parameter to the .readthedocs.yaml configuration file. Leaving out this parameter leads to failing builds on readthedocs as this parameter is a required parameter and not optional.