### PR TITLE
Limit the set of of retrieved temporary files

### DIFF
--- a/aiida_cusp/calculators/calculation_base.py
+++ b/aiida_cusp/calculators/calculation_base.py
@@ -100,14 +100,30 @@ class CalculationBase(CalcJob):
             help=("If set to `False` POSCAR in the restarted calculation will "
                   "not be replaced with CONTCAR form parent calculation")
         )
+        # define the list of calculation output files to be retrieved from
+        # the server by the daemon
+        spec.input(
+            'metadata.options.retrieve_files',
+            required=False,
+            non_db=True,
+            valid_type=list,
+            default=PluginDefaults.DEFAULT_RETRIEVE_LIST,
+        )
         # extend the metadata.options namespace with an additional
         # option to specify optional parser settings
-        spec.input_namespace('metadata.options.parser_settings',
-                             required=False, non_db=True, dynamic=True)
+        spec.input_namespace(
+            'metadata.options.parser_settings',
+            required=False,
+            non_db=True,
+            dynamic=True
+        )
         # this is the output node available to all connected parser for
         # storing their generated results (whatever these may be)
-        spec.output_namespace(PluginDefaults.PARSER_OUTPUT_NAMESPACE,
-                              required=False, dynamic=True)
+        spec.output_namespace(
+            PluginDefaults.PARSER_OUTPUT_NAMESPACE,
+            required=False,
+            dynamic=True
+        )
         # add dynamic sub-namespaces parsed_results.node_00 to
         # parsed_results.node_99 to provide possibly requird output ports for
         # neb results
@@ -311,13 +327,11 @@ class CalculationBase(CalcJob):
         """
         # get list of files to retrieve from parser_options.
         # if no options are given proceed with default list
-        settings = self.inputs.metadata.options.get('parser_settings', {})
-        parse_files = list(settings.get('parse_files', []))
-        parse_files = parse_files or PluginDefaults.DEFAULT_RETRIEVE_LIST
+        retrieve = list(self.inputs.metadata.options.get('retrieve_files'))
         retrieve_temporary = []
         # match files located both inside the working directory **and** in
         # possibl esubfolders of that directory (i.e NEB calculations)
-        for fname in parse_files:
+        for fname in retrieve:
             # FIXME: Once, support for older aiida-core versions is dropped
             #        the nesting specifier `2` can be replaced with `None`
             #        which was introduced with aiida-core 2.1.0

--- a/aiida_cusp/calculators/calculation_base.py
+++ b/aiida_cusp/calculators/calculation_base.py
@@ -316,6 +316,25 @@ class CalculationBase(CalcJob):
             if not file_parent_folder.exists():
                 file_parent_folder.mkdir(parents=True)
 
+    def files_to_retrieve(self):
+        """
+        Return the list of files to be retrieved from a calculation
+
+        This list contains the files to be retrieved defined by the user
+        as input to the calculation, complemented with all additional files
+        that are expected by the connected parser class
+        """
+        # get list of files to retrieve from parser_options.
+        # if no options are given proceed with default list
+        retrieve = list(self.inputs.metadata.options.get('retrieve_files'))
+        # get list of expected files, indicated as non-optional by the
+        # connected parser class
+        expected = self.expected_files()
+        # complement both lists if `expected` is not None
+        if expected is not None:
+            retrieve = list(set(retrieve + expected))
+        return retrieve
+
     def retrieve_temporary_list(self):
         """
         Defines the list of files marked for temporary retrieval.
@@ -325,9 +344,7 @@ class CalculationBase(CalcJob):
         Which of the files are actually kept is then decided by the
         subsequently running parser.
         """
-        # get list of files to retrieve from parser_options.
-        # if no options are given proceed with default list
-        retrieve = list(self.inputs.metadata.options.get('retrieve_files'))
+        retrieve = self.files_to_retrieve()
         retrieve_temporary = []
         # match files located both inside the working directory **and** in
         # possibl esubfolders of that directory (i.e NEB calculations)
@@ -367,6 +384,14 @@ class CalculationBase(CalcJob):
     def create_calculation_inputs(self, folder, calcinfo):
         """
         Write the calculation inputs and set the rerieve lists
+        (This method has to be implemented by the inherited subclass)
+        """
+        raise NotImplementedError
+
+    def expected_files(self):
+        """
+        Returns the list of expected files from the connected parser
+        class if defined
         (This method has to be implemented by the inherited subclass)
         """
         raise NotImplementedError

--- a/aiida_cusp/calculators/vasp_calculation.py
+++ b/aiida_cusp/calculators/vasp_calculation.py
@@ -132,3 +132,18 @@ class VaspCalculation(VaspBasicCalculation, VaspNebCalculation):
                                 "at the same time")
             if not poscar and not neb_path:
                 raise Exception("Missing non-optional structure input")
+
+    def expected_files(self):
+        """
+        Check the connected parser for a list of expected files
+        and return it to the caller if given
+        """
+        from aiida.plugins.factories import ParserFactory
+        parser = ParserFactory(self.get_connected_parser_name())
+        return parser.expected_files()
+
+    def get_connected_parser_name(self):
+        """
+        Return the connected parser name from the defined options
+        """
+        return self.inputs.metadata.options.get('parser_name')

--- a/aiida_cusp/parsers/parser_base.py
+++ b/aiida_cusp/parsers/parser_base.py
@@ -84,3 +84,22 @@ class ParserBase(Parser):
             return None
         except exceptions.ModificationNotAllowed:
             return self.exit_codes.ERRNO_DUPLICATE_LINKNAME
+
+    @staticmethod
+    def expected_files():
+        """
+        Define a list of files that are expected by the parser
+
+        If a list is defined, this list will be used to complement
+        the list of temporary retrieved files, defined by the
+        calculation.
+
+        If the parser does not expect a specific set of files, the
+        return value of this function has to be set to None
+
+        :returns: A list of files that are expected by the parser
+            or `None`
+        :rtype: `list` or `None`
+        """
+        # do not expect any files by default
+        return None

--- a/aiida_cusp/utils/defaults.py
+++ b/aiida_cusp/utils/defaults.py
@@ -101,6 +101,17 @@ class PluginDefaults(object):
     def PARSER_OUTPUT_NAMESPACE(cls):
         return "parsed_results"
 
+    # collection of VASP output files that will be retrieved by default (i.e.
+    # when no specific list of to retrieve was passed to the calculation)
+    @classproperty
+    def DEFAULT_RETRIEVE_LIST(cls):
+        default_retrieve_list = [
+            VaspDefaults.FNAMES['vasprun'],
+            VaspDefaults.FNAMES['outcar'],
+            VaspDefaults.FNAMES['contcar'],
+        ]
+        return default_retrieve_list
+
 
 class CustodianDefaults(object):
     """

--- a/docs/source/user_guide/calculators/vasp_calculator.rst
+++ b/docs/source/user_guide/calculators/vasp_calculator.rst
@@ -7,10 +7,24 @@ The :class:`~aiida_cusp.calculators.VaspCalculation` is available using the ``cu
 Similar to VASP itself the behavior of the calculation is entirely controllable by the passed input parameters defined for `KPOINTS`, `INCAR` and the `POTCAR` pseudo-potential.
 (Please refer to the :ref:`potcar command documentation<user-guide-commands-potcar>` how to add pseudo-potentials for VASP to the database)
 Whether a simple calculation or complex NEB calculation is run is decided by the calculation object based on the given structural inputs (i.e. ``poscar`` or ``neb_path``).
+
 Note that by default the output files containing calculation results are parsed using the :ref:`VaspFileParser class<user-guide-parsers-vaspfileparser>`.
 Of course the default parser may be changed to a different parser class using the calculation's `metadata.options.parser_class` option with corresponding parser options passed to the parser through the `metadata.options.parser_settings` option.
 For an overview of the available parsers and the accepted settings please refer to the :ref:`Parser section<user-guide-parsers>`.
-Despite the already mentioned, optional parser options the calculator accepts several other (non-)optional inputs that are used to setup the actual VASP calculation.
+
+Similarly, the `metadata.options.retrieve_files` setting allows the user to set an individual list of files to be retrieved from the calculation server.
+By default, `retrieve_files` is set to limit the group of retrieved calculation results to the following files:
+
+* `vasprun.xml`
+* `OUTCAR`
+* `CONTCAR`
+
+.. note::
+
+   Note that all files, expected and processed by the connected parser class, have to be defined in the `retrieve_files` list, passed to the calculation.
+   Failing to do so may likely result in an parsing error, ultimately failing the parsing process after the calculation has finished!
+
+Despite the above mentioned, optional parser and general options, the calculator accepts several other (non-)optional inputs that are used to setup the actual VASP calculation.
 In the following these calculation inputs are discussed and, for clarity, have been clustered into three main input groups that can be set with the calculation class:
 
 * :ref:`Vasp Calculation Inputs:<user-guide-calculators-vaspcalculator-inputs-vasp>`

--- a/docs/source/user_guide/calculators/vasp_calculator.rst
+++ b/docs/source/user_guide/calculators/vasp_calculator.rst
@@ -12,17 +12,12 @@ Note that by default the output files containing calculation results are parsed 
 Of course the default parser may be changed to a different parser class using the calculation's `metadata.options.parser_class` option with corresponding parser options passed to the parser through the `metadata.options.parser_settings` option.
 For an overview of the available parsers and the accepted settings please refer to the :ref:`Parser section<user-guide-parsers>`.
 
-Similarly, the `metadata.options.retrieve_files` setting allows the user to set an individual list of files to be retrieved from the calculation server.
-By default, `retrieve_files` is set to limit the group of retrieved calculation results to the following files:
-
-* `vasprun.xml`
-* `OUTCAR`
-* `CONTCAR`
+Similarly, the `metadata.options.retrieve_files` setting allows the user to set an individual list of files to be retrieved temporarily from the calculation server.
 
 .. note::
 
-   Note that all files, expected and processed by the connected parser class, have to be defined in the `retrieve_files` list, passed to the calculation.
-   Failing to do so may likely result in an parsing error, ultimately failing the parsing process after the calculation has finished!
+   Note, however, that files marked for temporary retrieval are usually the files that are used by the parser class connected to the calculation.
+   Thus, the files that should be on that list are usually defined by the connected parser class itself, and there should be no reason to fiddle with this list manually.
 
 Despite the above mentioned, optional parser and general options, the calculator accepts several other (non-)optional inputs that are used to setup the actual VASP calculation.
 In the following these calculation inputs are discussed and, for clarity, have been clustered into three main input groups that can be set with the calculation class:

--- a/tests/calculators/calculation_base_test.py
+++ b/tests/calculators/calculation_base_test.py
@@ -160,8 +160,9 @@ def test_prepare_for_submission_base_vasp(withmpi, vasp_code, cstdn_code,
         },
     }
     Base = CalculationBase(inputs=inputs)
-    # silence the NotImplementedError (we do not need these methods here)
+    # silence the NotImplementedErrors (we do not need these methods here)
     Base.create_calculation_inputs = lambda folder, calcinfo: calcinfo
+    Base.expected_files = lambda: None
     # run prepare_for_submission() to write the submit script to the
     # sandbox folder
     calcinfo = Base.presubmit(aiida_sandbox)
@@ -202,6 +203,7 @@ def test_prepare_for_submission_base_cstdn(withmpi, vasp_code, cstdn_code,
     Base = CalculationBase(inputs=inputs)
     # silence the NotImplementedError (we do not need these methods here)
     Base.create_calculation_inputs = lambda folder, calcinfo: calcinfo
+    Base.expected_files = lambda: None
     # run prepare_for_submission() to write the submit script to the
     # sandbox folder
     calcinfo = Base.presubmit(aiida_sandbox)
@@ -283,7 +285,7 @@ def test_calculation_restart_copy_remote(vasp_code, cstdn_code, tmpdir,
     # mock the central create_calculation_inputs() method which is defined
     # on the corresponding subclasses. here we simply replace it with a
     # a call to the restart_copy_remote() method (without any checks).
-    # additionally the custodian spec file is wriiten to check if it gets
+    # additionally the custodian spec file is written to check if it gets
     # accidentially copied to the working directory
     def mock(self, folder, calcinfo):
         self.restart_copy_remote(folder, calcinfo)
@@ -292,6 +294,7 @@ def test_calculation_restart_copy_remote(vasp_code, cstdn_code, tmpdir,
         return calcinfo
 
     monkeypatch.setattr(CalculationBase, 'create_calculation_inputs', mock)
+    monkeypatch.setattr(CalculationBase, 'expected_files', lambda self: None)
     # actually submit the calculation to check that remote contents are
     # indeed copied to the working directory
     calc_node = run_get_node(CalculationBase, **inputs)
@@ -306,10 +309,11 @@ def test_calculation_restart_copy_remote(vasp_code, cstdn_code, tmpdir,
         assert calc_file_content != remote_content
 
 
-def test_temporary_retrieve_list_default(vasp_code):
+@pytest.mark.parametrize('expected', [None, ['EXPECTED_FILE']])
+def test_temporary_retrieve_list_default(vasp_code, expected):
     """Test temporary_retrieve list contents when no user input was defined"""
     from aiida_cusp.calculators.calculation_base import CalculationBase
-    # the expected retrieve list
+    # the expected base retrieve list
     expected_list = [
         ('vasprun.xml', '.', 2),
         ('OUTCAR', '.', 2),
@@ -318,17 +322,23 @@ def test_temporary_retrieve_list_default(vasp_code):
         ('*/OUTCAR', '.', 2),
         ('*/CONTCAR', '.', 2),
     ]
+    if expected is not None:
+        expected_list.append((f'{expected[0]}', '.', 2))
+        expected_list.append((f'*/{expected[0]}', '.', 2))
     inputs = {
         'code': vasp_code,
         'metadata': {'options': {'resources': {'num_machines': 1}}},
     }
     calc_base = CalculationBase(inputs=inputs)
+    # setup the expected list that would have been returned by the parser
+    calc_base.expected_files = lambda: expected
     calc_temp_list = calc_base.retrieve_temporary_list()
     assert len(calc_temp_list) == len(set(calc_temp_list))
     assert set(calc_temp_list) == set(expected_list)
 
 
-def test_temporary_retrieve_list_user(vasp_code):
+@pytest.mark.parametrize('expected', [None, ['EXPECTED_FILE']])
+def test_temporary_retrieve_list_user(vasp_code, expected):
     """Test temporary_retrieve list contents when user input was defined"""
     from aiida_cusp.calculators.calculation_base import CalculationBase
     # the expected retrieve list
@@ -337,6 +347,9 @@ def test_temporary_retrieve_list_user(vasp_code):
         (f"{user_defined_file}", '.', 2),
         (f"*/{user_defined_file}", '.', 2),
     ]
+    if expected is not None:
+        expected_list.append((f'{expected[0]}', '.', 2))
+        expected_list.append((f'*/{expected[0]}', '.', 2))
     inputs = {
         'code': vasp_code,
         'metadata': {
@@ -347,12 +360,15 @@ def test_temporary_retrieve_list_user(vasp_code):
         },
     }
     calc_base = CalculationBase(inputs=inputs)
+    # setup the expected list that would have been returned by the parser
+    calc_base.expected_files = lambda: expected
     calc_temp_list = calc_base.retrieve_temporary_list()
     assert len(calc_temp_list) == len(set(calc_temp_list))
     assert set(calc_temp_list) == set(expected_list)
 
 
-def test_temporary_retrieve_list_user_empty(vasp_code):
+@pytest.mark.parametrize('expected', [None, ['EXPECTED_FILE']])
+def test_temporary_retrieve_list_user_empty(vasp_code, expected):
     """
     Test temporary_retrieve list contents when user input was defined
     but list is empty list
@@ -360,6 +376,9 @@ def test_temporary_retrieve_list_user_empty(vasp_code):
     from aiida_cusp.calculators.calculation_base import CalculationBase
     # the expected retrieve list
     expected_list = []
+    if expected is not None:
+        expected_list.append((f'{expected[0]}', '.', 2))
+        expected_list.append((f'*/{expected[0]}', '.', 2))
     inputs = {
         'code': vasp_code,
         'metadata': {
@@ -370,6 +389,8 @@ def test_temporary_retrieve_list_user_empty(vasp_code):
         },
     }
     calc_base = CalculationBase(inputs=inputs)
+    # setup the expected list that would have been returned by the parser
+    calc_base.expected_files = lambda: expected
     calc_temp_list = calc_base.retrieve_temporary_list()
     assert len(calc_temp_list) == len(set(calc_temp_list))
     assert set(calc_temp_list) == set(expected_list)

--- a/tests/calculators/calculation_base_test.py
+++ b/tests/calculators/calculation_base_test.py
@@ -306,13 +306,45 @@ def test_calculation_restart_copy_remote(vasp_code, cstdn_code, tmpdir,
         assert calc_file_content != remote_content
 
 
-def test_temporary_retrieve_list(vasp_code):
+def test_temporary_retrieve_list_default(vasp_code):
+    """Test temporary_retrieve list contents when no user input was defined"""
     from aiida_cusp.calculators.calculation_base import CalculationBase
     # the expected retrieve list
-    expected_list = set([('*', '.', 0)])
+    expected_list = [
+        ('vasprun.xml', '.', 2),
+        ('OUTCAR', '.', 2),
+        ('CONTCAR', '.', 2),
+        ('*/vasprun.xml', '.', 2),
+        ('*/OUTCAR', '.', 2),
+        ('*/CONTCAR', '.', 2),
+    ]
     inputs = {
         'code': vasp_code,
         'metadata': {'options': {'resources': {'num_machines': 1}}},
+    }
+    calc_base = CalculationBase(inputs=inputs)
+    calc_temp_list = calc_base.retrieve_temporary_list()
+    assert len(calc_temp_list) == len(set(calc_temp_list))
+    assert set(calc_temp_list) == set(expected_list)
+
+
+def test_temporary_retrieve_list_user(vasp_code):
+    """Test temporary_retrieve list contents when user input was defined"""
+    from aiida_cusp.calculators.calculation_base import CalculationBase
+    # the expected retrieve list
+    user_defined_file = 'USERFILE'
+    expected_list = [
+        (f"{user_defined_file}", '.', 2),
+        (f"*/{user_defined_file}", '.', 2),
+    ]
+    inputs = {
+        'code': vasp_code,
+        'metadata': {
+            'options': {
+                'resources': {'num_machines': 1},
+                'parser_settings': {'parse_files': [user_defined_file]},
+            },
+        },
     }
     calc_base = CalculationBase(inputs=inputs)
     calc_temp_list = calc_base.retrieve_temporary_list()

--- a/tests/calculators/calculation_base_test.py
+++ b/tests/calculators/calculation_base_test.py
@@ -342,7 +342,30 @@ def test_temporary_retrieve_list_user(vasp_code):
         'metadata': {
             'options': {
                 'resources': {'num_machines': 1},
-                'parser_settings': {'parse_files': [user_defined_file]},
+                'retrieve_files': [user_defined_file],
+            },
+        },
+    }
+    calc_base = CalculationBase(inputs=inputs)
+    calc_temp_list = calc_base.retrieve_temporary_list()
+    assert len(calc_temp_list) == len(set(calc_temp_list))
+    assert set(calc_temp_list) == set(expected_list)
+
+
+def test_temporary_retrieve_list_user_empty(vasp_code):
+    """
+    Test temporary_retrieve list contents when user input was defined
+    but list is empty list
+    """
+    from aiida_cusp.calculators.calculation_base import CalculationBase
+    # the expected retrieve list
+    expected_list = []
+    inputs = {
+        'code': vasp_code,
+        'metadata': {
+            'options': {
+                'resources': {'num_machines': 1},
+                'retrieve_files': [],
             },
         },
     }

--- a/tests/parsers/parser_base_test.py
+++ b/tests/parsers/parser_base_test.py
@@ -77,3 +77,11 @@ def test_register_output_nodes_method(vasp_code):
     # test storing the node with same linkname fails
     exit_code = parser.register_output_nodes([(linkname, node)])
     assert exit_code.status == 303
+
+
+def test_expected_files_method_default_value():
+    """
+    Assert that the expected_files() method returns `None` by default
+    """
+    from aiida_cusp.parsers.parser_base import ParserBase
+    assert ParserBase.expected_files() is None

--- a/tests/parsers/vasp_file_parser_test.py
+++ b/tests/parsers/vasp_file_parser_test.py
@@ -262,3 +262,11 @@ def test_output_node_namespaces(vasp_code, filepath, tmpdir):
     # is not available)
     for linkname, node in parser.outputs.items():
         vasp_calc.out(linkname, node)
+
+
+def test_list_of_essential_files():
+    """
+    Assert that the expected_files() method returns `None`
+    """
+    from aiida_cusp.parsers.vasp_file_parser import VaspFileParser
+    assert VaspFileParser.expected_files() is None


### PR DESCRIPTION
Fixes #30

After a calculation has finished the daemon downloads a set of the defined output files from the server, stores it temporarily for parsing and deletes them after parsing has finished. In the current implementation, the plugin would download **any** output file of the calculation, possibly generating a lot of unnecessary network traffic, due to the transfer of large, but unneeded, files. 

In this pull-request the current behavior is changed, such that, only a limited set of files, instead of all output files, is downloaded and stored temporarily by the daemon. This set of files may be defined by the user as additional parser setting upon defining and setting up the calculation. However, even if no user input was defined, the set of files that will be downloaded, is still limited to a sensible default set of files.