### PR TITLE
Improve GitHub actions and automatic publishing to PyPi 

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -12,9 +12,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Documentation Dependencies

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -9,9 +9,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Pre-Commit Dependencies
@@ -44,9 +44,9 @@ jobs:
         ports:
           - 5672:5672
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install `aiida-cusp` Package and Dependencies
@@ -77,9 +77,9 @@ jobs:
         ports:
           - 5672:5672
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install CodeCov Dependencies
@@ -92,7 +92,7 @@ jobs:
         run: |
             pytest --cov-report=xml --cov=aiida_cusp tests/
       - name: Upload recorded coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           name: aiida-cusp-coverage
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -2,6 +2,8 @@ name: unittests
 
 on:
   pull_request:
+    path_ignore:
+      - 'docs/**'
 
 jobs:
   pre-commit:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,7 +1,6 @@
 name: unittests
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/create_pypi_release.yml
+++ b/.github/workflows/create_pypi_release.yml
@@ -7,9 +7,9 @@ name: create-pypi-release
 # PyPi repository
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   # NOTE: verify-pkg-version **has** to be run before verify-release-tag

--- a/.github/workflows/create_pypi_release.yml
+++ b/.github/workflows/create_pypi_release.yml
@@ -128,8 +128,8 @@ jobs:
        with:
          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
          repository_url: https://test.pypi.org/legacy/
-     - name: Publish Distribution to PyPI
-       if: startsWith(github.ref, 'refs/tags/v')
-       uses: pypa/gh-action-pypi-publish@release/v1
-       with:
-         password: ${{ secrets.PYPI_API_TOKEN }}
+#     - name: Publish Distribution to PyPI
+#       if: startsWith(github.ref, 'refs/tags/v')
+#       uses: pypa/gh-action-pypi-publish@release/v1
+#       with:
+#         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/create_pypi_release.yml
+++ b/.github/workflows/create_pypi_release.yml
@@ -122,14 +122,14 @@ jobs:
      - name: Build PyPI Package
        run: |
          python -m build --sdist --outdir dist/
-     - name: Publish Distribution to Test-PyPI
-       if: startsWith(github.ref, 'refs/tags/v')
-       uses: pypa/gh-action-pypi-publish@release/v1
-       with:
-         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-         repository_url: https://test.pypi.org/legacy/
-#     - name: Publish Distribution to PyPI
+#     - name: Publish Distribution to Test-PyPI
 #       if: startsWith(github.ref, 'refs/tags/v')
 #       uses: pypa/gh-action-pypi-publish@release/v1
 #       with:
-#         password: ${{ secrets.PYPI_API_TOKEN }}
+#         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+#         repository_url: https://test.pypi.org/legacy/
+     - name: Publish Distribution to PyPI
+       if: startsWith(github.ref, 'refs/tags/v')
+       uses: pypa/gh-action-pypi-publish@release/v1
+       with:
+         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/create_pypi_release.yml
+++ b/.github/workflows/create_pypi_release.yml
@@ -19,9 +19,9 @@ jobs:
     #if: github.repository == 'aiida-cusp/aiida-cusp'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install `packaging` Dependency
@@ -35,9 +35,9 @@ jobs:
     needs: [verify-pkg-versions]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install `packaging` Dependency
@@ -51,9 +51,9 @@ jobs:
     needs: [verify-pkg-versions]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Pre-Commit Dependencies
@@ -87,9 +87,9 @@ jobs:
         ports:
           - 5672:5672
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.python_version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install `aiida-cusp` Package and Dependencies
@@ -110,9 +110,9 @@ jobs:
     name: Build and Publish Package to PyPI
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v3
      - name: Setup Python 3.8 Build Environment
-       uses: actions/setup-python@v3
+       uses: actions/setup-python@v4
        with:
          python-version: "3.8"
      - name: Install pypa/build Requirement

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -13,9 +13,9 @@ jobs:
     #if: github.repository == 'aiida-cusp/aiida-cusp'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install `packaging` Dependency


### PR DESCRIPTION
This pull request introduces some small modifications to the existing GitHub actions:

* Only run documentation builds when the docs are actually changed
* Do not run complete CI suite of only the docs were changed
* Automatically publish a new release to PyPi if tags are created 